### PR TITLE
Set AWS region from CLI default

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -6,6 +6,7 @@ export const config = {
   ELASTICSEARCH_ENDPOINT: process.env.ELASTICSEARCH_ENDPOINT || '',
   SCALE_DOWN_SERVICE: process.env.SCALE_DOWN_SERVICE || '',
   NUMBER_OF_SHARDS: process.env.NUMBER_OF_SHARDS || 1,
+  AWS_REGION: process.env.AWS_DEFAULT_REGION || ''
 }
 
 export type Config = typeof config


### PR DESCRIPTION
This is because the AWS Node SDK uses the variable `AWS_REGION` whereas the AWS CLI uses `AWS_DEFAULT_REGION`. 

https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-region.html